### PR TITLE
2차 QA 오류 수정

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -50,28 +50,3 @@ if ("serviceWorker" in navigator) {
       });
   });
 }
-if (import.meta.env.DEV) {
-  const { worker } = await import("./mocks/browser");
-  worker.start({
-    onUnhandledRequest: "bypass",
-    serviceWorker: {
-      url: "/mockServiceWorker.js",
-      options: {
-        scope: "/api/",
-      },
-    },
-  });
-}
-// service worker 등록
-if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker
-      .register("/sw.js")
-      .then(reg => {
-        console.log("Service worker registered:", reg);
-      })
-      .catch(err => {
-        console.error("Service worker registration failed:", err);
-      });
-  });
-}

--- a/src/entities/d-day/mutation.ts
+++ b/src/entities/d-day/mutation.ts
@@ -16,7 +16,7 @@ export const useCreateDdayMutation = (data: DdayRequst) => {
   return useMutation({
     mutationFn: () => createDday(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(date).queryKey });
@@ -40,7 +40,7 @@ export const useUpdateDdayMutation = (data: DdayRequst) => {
   return useMutation({
     mutationFn: () => updateDday(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(date).queryKey });
@@ -60,7 +60,7 @@ export const useDeleteDdayMutation = (ddayId: string, date: string) => {
   return useMutation({
     mutationFn: () => deleteDday(ddayId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(newDate).queryKey });

--- a/src/entities/d-day/mutation.ts
+++ b/src/entities/d-day/mutation.ts
@@ -55,10 +55,6 @@ export const useUpdateDdayMutation = (data: DdayRequst) => {
 export const useDeleteDdayMutation = (ddayId: string, date: string) => {
   const queryClient = useQueryClient();
 
-  if (!ddayId) {
-    throw new Error("디데이 삭제에 필요한 ID가 없습니다.");
-  }
-
   const newDate = new Date(date);
 
   return useMutation({

--- a/src/entities/d-day/mutation.ts
+++ b/src/entities/d-day/mutation.ts
@@ -16,7 +16,7 @@ export const useCreateDdayMutation = (data: DdayRequst) => {
   return useMutation({
     mutationFn: () => createDday(data),
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.refetchQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(date).queryKey });
@@ -40,7 +40,7 @@ export const useUpdateDdayMutation = (data: DdayRequst) => {
   return useMutation({
     mutationFn: () => updateDday(data),
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.refetchQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(date).queryKey });
@@ -60,7 +60,7 @@ export const useDeleteDdayMutation = (ddayId: string, date: string) => {
   return useMutation({
     mutationFn: () => deleteDday(ddayId),
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ddayQueryKey.list().queryKey });
+      queryClient.refetchQueries({ queryKey: ddayQueryKey.list().queryKey });
       queryClient.invalidateQueries({ queryKey: ddayQueryKey.main().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.week().queryKey });
       queryClient.invalidateQueries({ queryKey: scheduleQueryKey.list(newDate).queryKey });

--- a/src/entities/d-day/query.ts
+++ b/src/entities/d-day/query.ts
@@ -4,7 +4,7 @@ import { getDdayList } from "./service";
 
 export const useGetDdayList = () => {
   return useInfiniteQuery({
-    ...ddayQueryKey.list(),
+    queryKey: ddayQueryKey.list().queryKey,
     queryFn: async ({ pageParam = 1 }) => {
       return getDdayList({
         page: pageParam,

--- a/src/entities/letter/mutation.ts
+++ b/src/entities/letter/mutation.ts
@@ -12,7 +12,7 @@ export const useCreateLetterMutation = (scheduleId: string) => {
       queryClient.invalidateQueries({
         queryKey: scheduleQueryKey.detail(scheduleId).queryKey,
       });
-      queryClient.invalidateQueries({
+      queryClient.refetchQueries({
         queryKey: letterQueryKey.list().queryKey,
       });
     },
@@ -28,7 +28,7 @@ export const useDeleteLetterMutation = (scheduleId: string, letterId: string) =>
   return useMutation({
     mutationFn: async () => await deleteLetter(scheduleId, letterId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      queryClient.refetchQueries({
         queryKey: letterQueryKey.list().queryKey,
       });
       queryClient.invalidateQueries({
@@ -47,7 +47,7 @@ export const useUpdateLetterMutation = (scheduleId: string) => {
   return useMutation({
     mutationFn: async (data: UpdateLetterRequest) => await updateLetter(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      queryClient.refetchQueries({
         queryKey: letterQueryKey.list().queryKey,
       });
       queryClient.invalidateQueries({

--- a/src/entities/letter/query.ts
+++ b/src/entities/letter/query.ts
@@ -8,7 +8,7 @@ export const useGetLetterDetail = (scheduleId: string, letterId: string) => {
 
 export const useGetLetterList = () => {
   return useInfiniteQuery({
-    ...letterQueryKey.list(),
+    queryKey: letterQueryKey.list().queryKey,
     queryFn: async ({ pageParam = 1 }) => {
       return getLetterList({
         page: pageParam,

--- a/src/entities/letter/type.ts
+++ b/src/entities/letter/type.ts
@@ -8,6 +8,7 @@ export interface Letter {
   content: string;
   pictureUrl: string;
   createdAt: string;
+  isWrittenByMe: boolean;
   comments: Comment[];
 }
 

--- a/src/entities/main_letter/types.ts
+++ b/src/entities/main_letter/types.ts
@@ -1,5 +1,6 @@
 export interface Letter {
-  letterId: number;
+  letterId: string;
+  scheduleId: string;
   title: string;
   content: string;
   pictureUrl: string;
@@ -14,4 +15,4 @@ export interface LetterListResponse {
 export interface GetLetterListToMeParams {
   key?: number;
   take?: number;
-} 
+}

--- a/src/features/d-day/ui/NoDdayMessage.tsx
+++ b/src/features/d-day/ui/NoDdayMessage.tsx
@@ -1,7 +1,14 @@
 import noDday from "@/assets/images/noDday.svg";
 import { Button } from "@/shared/ui";
+import { useNavigate } from "react-router";
 
 export const NoDdayMessage = () => {
+  const navigate = useNavigate();
+
+  const goCreateDdayPage = () => {
+    navigate("/calendar/dday/new", { state: { from: "/calendar/dday" } });
+  };
+
   return (
     <div className="mt-[170px] flex flex-col items-center">
       <img src={noDday} alt="Day 없음" />
@@ -11,7 +18,7 @@ export const NoDdayMessage = () => {
         <br />
         편지를 작성해보는 건 어떨까요?
       </p>
-      <Button variant="square" size="2xs" className="mt-8">
+      <Button variant="square" size="2xs" className="mt-8" onClick={goCreateDdayPage}>
         디데이 추가
       </Button>
     </div>

--- a/src/features/letter/WriteLetterBottomSheet.tsx
+++ b/src/features/letter/WriteLetterBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, ChangeEvent, FormEvent } from "react";
+import { useState, useRef, FormEvent } from "react";
 import { Button, Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger, SInput, Textarea } from "@/shared/ui";
 import { Carousel, CarouselContent, CarouselItem } from "@/shared/ui";
 import crossDeleteIcon from "@/assets/icons/crossDelete.svg";
@@ -28,7 +28,7 @@ export const WriteLetterBottomSheet = ({
   // 상태: 수정 모드면 기존 값, 생성 모드면 빈 값
   const [editTitle, setEditTitle] = useState(title);
   const [editContent, setEditContent] = useState(content);
-  // const [editImagesUrl, setEditImagesUrl] = useState<string[]>(imagesUrl);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [images, setImages] = useState<File[]>([]);
   const MAX_IMAGES = 3;
@@ -60,8 +60,10 @@ export const WriteLetterBottomSheet = ({
   };
 
   // 폼 제출 핸들러 (생성/수정 분기)
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (isSubmitting) return;
 
     if (!editTitle.trim()) {
       alert("제목을 입력해주세요.");
@@ -71,6 +73,8 @@ export const WriteLetterBottomSheet = ({
       alert("내용을 입력해주세요.");
       return;
     }
+
+    setIsSubmitting(true);
 
     const upsertLetterRequest = {
       letterId: isEdit ? letterId : null,
@@ -94,10 +98,16 @@ export const WriteLetterBottomSheet = ({
         {
           onSuccess: () => {
             alert("편지가 수정되었습니다.");
+            setEditTitle("");
+            setEditContent("");
+            setImages([]);
             onToggle();
           },
           onError: error => {
             console.error(error);
+          },
+          onSettled: () => {
+            setIsSubmitting(false);
           },
         }
       );
@@ -105,10 +115,16 @@ export const WriteLetterBottomSheet = ({
       mutate(finalFormData, {
         onSuccess: () => {
           alert("편지가 등록되었습니다.");
+          setEditTitle("");
+          setEditContent("");
+          setImages([]);
           onToggle();
         },
         onError: error => {
           console.error(error);
+        },
+        onSettled: () => {
+          setIsSubmitting(false);
         },
       });
     }
@@ -131,7 +147,8 @@ export const WriteLetterBottomSheet = ({
             <Button
               type="submit"
               variant="ghost"
-              className="hover:bg-gray-0 p-0 text-sm font-semibold text-green-600 hover:text-green-700">
+              disabled={isSubmitting}
+              className="hover:bg-gray-0 p-0 text-sm font-semibold text-green-600 hover:text-green-700 disabled:text-green-300">
               완료
             </Button>
           </DrawerHeader>

--- a/src/features/letter/WriteLetterBottomSheet.tsx
+++ b/src/features/letter/WriteLetterBottomSheet.tsx
@@ -114,7 +114,7 @@ export const WriteLetterBottomSheet = ({
   return (
     <Drawer open={isToggle} onOpenChange={onToggle}>
       <DrawerTrigger asChild>{children}</DrawerTrigger>
-      <DrawerContent className="py10 px-5">
+      <DrawerContent className="px-5 pt-2 pb-15">
         <form className="mx-auto w-full max-w-sm" onSubmit={handleSubmit}>
           <DrawerHeader className="flex-row justify-between px-0">
             <Button

--- a/src/features/letter/WriteLetterBottomSheet.tsx
+++ b/src/features/letter/WriteLetterBottomSheet.tsx
@@ -212,7 +212,7 @@ export const WriteLetterBottomSheet = ({
                     {images.map((image, index) => {
                       const objectUrl = URL.createObjectURL(image);
                       return (
-                        <CarouselItem key={index} className="relative md:basis-1/2 lg:basis-1/2">
+                        <CarouselItem key={index} className="relative max-w-50 md:basis-1/2 lg:basis-1/2">
                           <div className="p-1">
                             <img
                               src={objectUrl}

--- a/src/features/letter/WriteLetterBottomSheet.tsx
+++ b/src/features/letter/WriteLetterBottomSheet.tsx
@@ -31,6 +31,7 @@ export const WriteLetterBottomSheet = ({
   // const [editImagesUrl, setEditImagesUrl] = useState<string[]>(imagesUrl);
 
   const [images, setImages] = useState<File[]>([]);
+  const MAX_IMAGES = 3;
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { isToggle, onToggle } = useToggle();
@@ -38,16 +39,18 @@ export const WriteLetterBottomSheet = ({
   const { mutate } = useCreateLetterMutation(scheduleId || "");
   const { mutate: updateMutate } = useUpdateLetterMutation(scheduleId || "");
 
-  // 이미지 선택 시 처리
-  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files) {
-      const selectedFiles = Array.from(event.target.files);
-      setImages(prev => [...prev, ...selectedFiles]);
+  const handleImageUpload = (files: FileList) => {
+    const remainingSlots = MAX_IMAGES - images.length;
+    if (remainingSlots <= 0) {
+      alert("이미지는 최대 3개까지만 등록할 수 있습니다.");
+      return;
     }
+
+    const newImages = Array.from(files).slice(0, remainingSlots);
+    setImages(prev => [...prev, ...newImages]);
   };
 
-  // 이미지 삭제
-  const handleRemoveImage = (index: number) => {
+  const handleImageDelete = (index: number) => {
     setImages(prev => prev.filter((_, i) => i !== index));
   };
 
@@ -178,7 +181,11 @@ export const WriteLetterBottomSheet = ({
                   multiple
                   accept="image/*"
                   ref={fileInputRef}
-                  onChange={handleImageChange}
+                  onChange={e => {
+                    if (e.target.files) {
+                      handleImageUpload(e.target.files);
+                    }
+                  }}
                 />
               </div>
 
@@ -201,7 +208,7 @@ export const WriteLetterBottomSheet = ({
                               size="2xsIcon"
                               type="button"
                               className="absolute top-3 right-3"
-                              onClick={() => handleRemoveImage(index)}
+                              onClick={() => handleImageDelete(index)}
                               aria-label="이미지 삭제">
                               <img src={crossDeleteIcon} alt="이미지 삭제" />
                             </Button>

--- a/src/features/letter/ui/LetterCard.tsx
+++ b/src/features/letter/ui/LetterCard.tsx
@@ -22,6 +22,7 @@ interface LetterCardProps {
   content: string;
   createdAt: string;
   pictureUrl?: string;
+  isWrittenByMe: boolean;
 }
 
 export const LetterCard = (props: LetterCardProps) => {
@@ -69,20 +70,22 @@ export const LetterCard = (props: LetterCardProps) => {
         </div>
         <div className="mt-3 flex justify-between">
           <InfoCard.Text>{formatDateFull(props.createdAt)}</InfoCard.Text>
-          <InfoCard.Options className="items-center">
-            <WriteLetterBottomSheet title={props.title} content={props.content} letterId={props.letterId}>
-              <InfoCard.Option>편집</InfoCard.Option>
-            </WriteLetterBottomSheet>
-            <span className="align-middl inline-block h-3 w-[1.5px] bg-gray-300" />
-            <DeleteAlert
-              onDelete={handleDelete}
-              title="편지 삭제"
-              description="정말 편지를 삭제하시겠어요?"
-              buttonText="삭제"
-              cancelText="취소">
-              <InfoCard.Option>삭제</InfoCard.Option>
-            </DeleteAlert>
-          </InfoCard.Options>
+          {props.isWrittenByMe && (
+            <InfoCard.Options className="items-center">
+              <WriteLetterBottomSheet title={props.title} content={props.content} letterId={props.letterId}>
+                <InfoCard.Option>편집</InfoCard.Option>
+              </WriteLetterBottomSheet>
+              <span className="align-middl inline-block h-3 w-[1.5px] bg-gray-300" />
+              <DeleteAlert
+                onDelete={handleDelete}
+                title="편지 삭제"
+                description="정말 편지를 삭제하시겠어요?"
+                buttonText="삭제"
+                cancelText="취소">
+                <InfoCard.Option>삭제</InfoCard.Option>
+              </DeleteAlert>
+            </InfoCard.Options>
+          )}
         </div>
       </InfoCard.Content>
     </InfoCard>

--- a/src/features/letter/ui/LetterCard.tsx
+++ b/src/features/letter/ui/LetterCard.tsx
@@ -1,5 +1,5 @@
 // 외부 라이브러리 import
-import { useNavigate, useParams } from "react-router";
+import { useLocation, useNavigate, useParams } from "react-router";
 
 // 훅
 import { useDeleteLetterMutation } from "@/entities/letter/mutation";
@@ -29,6 +29,7 @@ export const LetterCard = (props: LetterCardProps) => {
 
   // 라우터 훅
   const navigate = useNavigate();
+  const location = useLocation();
 
   // API 훅
   const { mutate } = useDeleteLetterMutation(scheduleId || "", props.letterId);
@@ -52,8 +53,10 @@ export const LetterCard = (props: LetterCardProps) => {
     });
   };
 
+  const letterListPath = location.pathname === "/calendar/letters" ? true : false;
+
   return (
-    <InfoCard onClick={handleClick}>
+    <InfoCard onClick={handleClick} className={letterListPath ? "bg-gray-50" : ""}>
       <InfoCard.Content className="flex-col">
         <div className="flex items-center gap-4">
           {props.pictureUrl && <InfoCard.Image imageUrl={props.pictureUrl} />}
@@ -62,7 +65,7 @@ export const LetterCard = (props: LetterCardProps) => {
             <InfoCard.Text>{props.content}</InfoCard.Text>
           </div>
         </div>
-        <div className=" mt-3 flex justify-between">
+        <div className="mt-3 flex justify-between">
           <InfoCard.Text>{formatDateFull(props.createdAt)}</InfoCard.Text>
           <InfoCard.Options className="items-center">
             <WriteLetterBottomSheet title={props.title} content={props.content} letterId={props.letterId}>

--- a/src/features/letter/ui/LetterCard.tsx
+++ b/src/features/letter/ui/LetterCard.tsx
@@ -33,7 +33,7 @@ export const LetterCard = (props: LetterCardProps) => {
   const location = useLocation();
 
   // API 훅
-  const { mutate } = useDeleteLetterMutation(scheduleId || props.letterId, props.letterId);
+  const { mutate } = useDeleteLetterMutation(scheduleId || props.scheduleId, props.letterId);
 
   // 이벤트 핸들러
   const handleClick = (event: MouseEvent) => {

--- a/src/features/letter/ui/LetterCard.tsx
+++ b/src/features/letter/ui/LetterCard.tsx
@@ -17,6 +17,7 @@ import { WriteLetterBottomSheet } from "../WriteLetterBottomSheet";
 
 interface LetterCardProps {
   letterId: string;
+  scheduleId: string;
   title: string;
   content: string;
   createdAt: string;
@@ -32,13 +33,14 @@ export const LetterCard = (props: LetterCardProps) => {
   const location = useLocation();
 
   // API 훅
-  const { mutate } = useDeleteLetterMutation(scheduleId || "", props.letterId);
+  const { mutate } = useDeleteLetterMutation(scheduleId || props.letterId, props.letterId);
 
   // 이벤트 핸들러
   const handleClick = (event: MouseEvent) => {
+    const defaultScheduleId = scheduleId || props.scheduleId;
     const tagName = (event.target as HTMLElement).tagName.toLowerCase();
     if (["button", "input", "textarea", "svg", "path"].includes(tagName)) return;
-    navigate(`/calendar/schedule/${scheduleId}/letter/${props.letterId}`);
+    navigate(`/calendar/schedule/${defaultScheduleId}/letter/${props.letterId}`);
   };
 
   const handleDelete = (e: MouseEvent) => {

--- a/src/features/mainpage/DDaySection.tsx
+++ b/src/features/mainpage/DDaySection.tsx
@@ -6,19 +6,19 @@ import { DdayCard } from "../d-day/ui";
 import CakeIcon from "@/assets/images/cake.svg";
 interface DDaySectionProps {
   isConnected: boolean;
+  isInitialized: boolean;
 }
 
-export const DDaySection = ({ isConnected }: DDaySectionProps) => {
+export const DDaySection = ({ isConnected, isInitialized }: DDaySectionProps) => {
   const { data: mainDdayList } = useGetMainDdayList(isConnected);
   const navigate = useNavigate();
 
-  if (!isConnected || !mainDdayList) {
+  if (!isConnected || !isInitialized || !mainDdayList) {
     return (
       <>
-        <MainHeader mainTitle="D-DAY" buttonText="더보기" onClick={() => {}} />
-        <div className="mb-5 flex items-center rounded-2xl bg-white p-6 text-md font-semibold text-gray-500">
-          <img src={CakeIcon} alt="하트" className="mr-2 h-7 w-7 opacity-50" />
-
+        <MainHeader mainTitle="D-DAY" buttonText="더보기" isConnected={isConnected} isInitialized={isInitialized} />
+        <div className="text-md mb-15 flex items-center rounded-2xl bg-white p-6 font-semibold text-gray-500">
+          <img src={CakeIcon} alt="하트" className="mr-2 h-5 w-5 opacity-50" />
           <span>상대방과의 소중한 디데이를 등록하세요</span>
         </div>
       </>
@@ -31,13 +31,21 @@ export const DDaySection = ({ isConnected }: DDaySectionProps) => {
         mainTitle="D-DAY"
         buttonText="더보기"
         onClick={() => navigate("/calendar/dday", { state: { from: "/" } })}
+        isConnected={isConnected}
+        isInitialized={isInitialized}
       />
-
-      <ul className="mb-5 flex flex-col gap-3">
-        {mainDdayList.result.map(dday => (
-          <DdayCard key={dday.id} {...dday} className="bg-white" />
-        ))}
-      </ul>
+      {mainDdayList.result.length > 0 ? (
+        <ul className="mb-5 flex flex-col gap-3">
+          {mainDdayList.result.map(dday => (
+            <DdayCard key={dday.id} {...dday} className="bg-white" />
+          ))}
+        </ul>
+      ) : (
+        <div className="text-md mb-15 flex items-center rounded-2xl bg-white p-6 font-semibold text-gray-500">
+          <img src={CakeIcon} alt="하트" className="mr-2 h-5 w-5 opacity-50" />
+          <span>상대방과의 소중한 디데이를 등록하세요</span>
+        </div>
+      )}
     </>
   );
 };

--- a/src/features/mainpage/LetterSection.tsx
+++ b/src/features/mainpage/LetterSection.tsx
@@ -14,14 +14,27 @@ interface LetterSectionProps {
 export const LetterSection = ({ isConnected, isInitialized }: LetterSectionProps) => {
   const enabled = isConnected || isInitialized;
   const { data: letterList } = useGetLetterListMain(enabled);
+
   const navigate = useNavigate();
 
- 
+  const handleLetterListRedirect = () => {
+    if (isConnected) {
+      navigate("/calendar/letters", {
+        state: { previousPath: window.location.pathname },
+      });
+    }
+  };
 
-  if (!isConnected || !isInitialized||!letterList?.result || letterList.result.length === 0) {
+  if (!isConnected || !isInitialized || !letterList?.result || letterList.result.length === 0) {
     return (
       <>
-        <MainHeader mainTitle="도착한 편지" buttonText="더보기" onClick={() => {}} />
+        <MainHeader
+          mainTitle="도착한 편지"
+          buttonText="더보기"
+          onClick={handleLetterListRedirect}
+          isConnected={isConnected}
+          isInitialized={isInitialized}
+        />
         <div className="flex h-[140px] w-[190px] flex-col gap-2.5 rounded-2xl bg-white p-4">
           <div className="flex flex-col">
             <div className="flex items-center gap-1">
@@ -41,7 +54,13 @@ export const LetterSection = ({ isConnected, isInitialized }: LetterSectionProps
 
   return (
     <>
-      <MainHeader mainTitle="도착한 편지" buttonText="더보기" onClick={() => navigate("/calendar/letters")} />
+      <MainHeader
+        mainTitle="도착한 편지"
+        buttonText="더보기"
+        onClick={handleLetterListRedirect}
+        isConnected={isConnected}
+        isInitialized={isInitialized}
+      />
       <div className="relative w-full overflow-x-auto">
         <Carousel
           opts={{

--- a/src/features/mainpage/LetterSection.tsx
+++ b/src/features/mainpage/LetterSection.tsx
@@ -25,6 +25,10 @@ export const LetterSection = ({ isConnected, isInitialized }: LetterSectionProps
     }
   };
 
+  const handleLetterCardClick = (letterId: string, scheduleId: string) => {
+    navigate(`/calendar/schedule/${scheduleId}/letter/${letterId}`);
+  };
+
   if (!isConnected || !isInitialized || !letterList?.result || letterList.result.length === 0) {
     return (
       <>
@@ -71,7 +75,10 @@ export const LetterSection = ({ isConnected, isInitialized }: LetterSectionProps
           className="w-full">
           <CarouselContent className="-ml-4 gap-3">
             {letterList.result.map(letter => (
-              <CarouselItem key={letter.letterId} className="basis-[190px] pl-4">
+              <CarouselItem
+                key={letter.letterId}
+                className="basis-[190px] pl-4"
+                onClick={() => handleLetterCardClick(letter.letterId, letter.scheduleId)}>
                 <div className="h-[140px] w-[190px] flex-col gap-2.5 rounded-2xl bg-white p-4">
                   <div className="flex h-full flex-col justify-between">
                     <div>

--- a/src/features/mainpage/ScheduleSection.tsx
+++ b/src/features/mainpage/ScheduleSection.tsx
@@ -3,23 +3,47 @@ import { MainScheduleCardList, MiniCalendar } from "../schedule";
 import { ErrorBoundary } from "react-error-boundary";
 import { MainHeader } from "./ui/MainHeader";
 import { SelectedDateProvider } from "../schedule/context/SelectedDateContext";
+import { useNavigate } from "react-router";
+import CalendarBlack from "@/assets/images/calendar_black.svg";
 
-export const ScheduleSection = () => {
+interface ScheduleSectionProps {
+  isConnected: boolean;
+  isInitialized: boolean;
+}
+
+export const ScheduleSection = ({ isConnected, isInitialized }: ScheduleSectionProps) => {
+  const navigate = useNavigate();
+
+  const hadleMoveCalendar = () => {
+    navigate("/calendar/schedule");
+  };
+
   return (
     <SelectedDateProvider>
-      <MainHeader mainTitle="우리의 일정" onClick={() => console.log("일정 더보기")} />
-      <section className="mx-auto w-full max-w-md rounded-2xl bg-white py-4">
+      <MainHeader
+        mainTitle="우리의 일정"
+        onClick={hadleMoveCalendar}
+        isConnected={isConnected}
+        isInitialized={isInitialized}
+      />
+      <section className="mx-auto w-full max-w-md rounded-2xl bg-white px-4 py-4">
         <ErrorBoundary fallback={<div>에러 발생</div>}>
           <Suspense fallback={<div>로딩중</div>}>
-            <MiniCalendar />
+            <MiniCalendar isConnected={isConnected} isInitialized={isInitialized} />
           </Suspense>
         </ErrorBoundary>
-
-        <ErrorBoundary fallback={<div>에러 발생</div>}>
-          <Suspense fallback={<div>로딩중...</div>}>
-            <MainScheduleCardList />
-          </Suspense>
-        </ErrorBoundary>
+        {isConnected && isInitialized ? (
+          <ErrorBoundary fallback={<div>에러 발생</div>}>
+            <Suspense fallback={<div>로딩중...</div>}>
+              <MainScheduleCardList />
+            </Suspense>
+          </ErrorBoundary>
+        ) : (
+          <div className="flex w-full max-w-md items-center justify-start gap-1 rounded-2xl bg-gray-50 px-4 py-6">
+            <img className="h-5 w-5" src={CalendarBlack} alt="캘린더 아이콘" />
+            <p className="text-md font-medium text-gray-500">서로의 일정을 공유해보세요.</p>
+          </div>
+        )}
       </section>
     </SelectedDateProvider>
   );

--- a/src/features/mainpage/StatusSection.tsx
+++ b/src/features/mainpage/StatusSection.tsx
@@ -10,19 +10,19 @@ interface StatusSectionProps {
 }
 
 const EMOTION_TO_ICON: Record<string, keyof typeof EMOTION_IMAGES> = {
-  "MISS": "miss",
-  "HAPPY": "happy",
-  "COMMON": "common",
-  "TIRED": "tired",
-  "SAD": "sad",
-  "WORRY": "worry",
-  "ANGRY": "angry",
+  MISS: "miss",
+  HAPPY: "happy",
+  COMMON: "common",
+  TIRED: "tired",
+  SAD: "sad",
+  WORRY: "worry",
+  ANGRY: "angry",
 };
 
 export const StatusSection = ({ isConnected, isInitialized }: StatusSectionProps) => {
   const navigate = useNavigate();
   const { getCoupleEmotion, getStatusMessage } = useEmotionStatusQueries({
-    enabled: isConnected && isInitialized
+    enabled: isConnected && isInitialized,
   });
   const emotion = getCoupleEmotion.data?.data?.result?.emotion ?? "";
   const statusMessage = getStatusMessage.data?.data?.result?.statusMessage ?? "";
@@ -33,9 +33,10 @@ export const StatusSection = ({ isConnected, isInitialized }: StatusSectionProps
     }
   };
 
-  const EmotionIcon = isConnected && isInitialized && emotion && EMOTION_TO_ICON[emotion] 
-    ? EMOTION_IMAGES[EMOTION_TO_ICON[emotion]].base 
-    : null;
+  const EmotionIcon =
+    isConnected && isInitialized && emotion && EMOTION_TO_ICON[emotion]
+      ? EMOTION_IMAGES[EMOTION_TO_ICON[emotion]].base
+      : null;
 
   return (
     <>
@@ -44,20 +45,22 @@ export const StatusSection = ({ isConnected, isInitialized }: StatusSectionProps
         buttonText="상태 메세지 쓰러가기"
         onClick={handleStatusClick}
         disabled={!isConnected || !isInitialized}
+        isConnected={isConnected}
+        isInitialized={isInitialized}
       />
-      <section className=" rounded-2xl bg-white p-6">
+      <section className="rounded-2xl bg-white p-6">
         <div className="flex items-center text-sm font-semibold">
           {EmotionIcon ? (
             <EmotionIcon className="mr-3 h-5 w-5" />
           ) : (
             <img src={CharacterDefaultIcon} alt="캐릭터" className="mr-3 h-6 w-6" />
           )}
-          <span className={`font-semibold text-md ${statusMessage ? "text-gray-900" : "text-gray-500"}`}>
+          <span className={`text-md font-semibold ${statusMessage ? "text-gray-900" : "text-gray-500"}`}>
             {!isConnected
               ? "커플 연결을 해주세요."
               : !isInitialized
-              ? "초기 설정을 해주세요."
-              : statusMessage || "오늘 기분은 어떤가요?"}
+                ? "초기 설정을 해주세요."
+                : statusMessage || "오늘 기분은 어떤가요?"}
           </span>
         </div>
       </section>

--- a/src/features/mainpage/ui/CopleCheckAlert.tsx
+++ b/src/features/mainpage/ui/CopleCheckAlert.tsx
@@ -1,0 +1,53 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTrigger,
+  AlertDialogCancel,
+} from "@/shared/ui";
+import { AlertDialogTitle } from "@radix-ui/react-alert-dialog";
+import { useNavigate } from "react-router";
+
+export const CopleCheckAlert = () => {
+  const navigate = useNavigate();
+
+  const handleIsConnectedCheck = () => {
+    navigate("/onboarding/couple-contact", {
+      state: { previousPath: window.location.pathname },
+    });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button className="flex cursor-pointer items-center gap-1 text-sm font-medium text-gray-700">
+          더보기
+          <span>{">"}</span>
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="w-80">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-center text-lg font-semibold">커플 연결을 해주세요</AlertDialogTitle>
+          <AlertDialogDescription className="text-center text-xs font-normal text-gray-400">
+            서로의 초대코드를 입력하면 커플 연결이 완료돼요!
+            <br />
+            연결은 계정당 한 번만 가능해요
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-row !justify-center">
+          <AlertDialogAction
+            className="hover:bg-gray-1000 w-[50%] bg-gray-900 p-3 text-sm font-semibold text-white hover:text-white"
+            onClick={handleIsConnectedCheck}>
+            연결하러가기
+          </AlertDialogAction>
+          <AlertDialogCancel className="w-[50%] bg-gray-200 p-3 text-sm font-semibold text-white hover:bg-gray-300 hover:text-white">
+            취소
+          </AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/features/mainpage/ui/InitializedCheckAlert.tsx
+++ b/src/features/mainpage/ui/InitializedCheckAlert.tsx
@@ -1,0 +1,51 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTrigger,
+  AlertDialogCancel,
+} from "@/shared/ui";
+import { AlertDialogTitle } from "@radix-ui/react-alert-dialog";
+import { useNavigate } from "react-router";
+
+export const InitializedCheckAlert = () => {
+  const navigate = useNavigate();
+
+  const handleIsInitializedCheck = () => {
+    navigate("/onboarding/firstmeet", {
+      state: { previousPath: window.location.pathname },
+    });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button className="flex cursor-pointer items-center gap-1 text-sm font-medium text-gray-700">
+          더보기
+          <span>{">"}</span>
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="w-80">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-center text-lg font-semibold">초기 설정을 해주세요</AlertDialogTitle>
+          <AlertDialogDescription className="text-center text-xs font-normal text-gray-400">
+            초기 설정을 하면 서비스를 이용할 수 있어요!
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-row !justify-center">
+          <AlertDialogAction
+            className="hover:bg-gray-1000 w-[50%] bg-gray-900 p-3 text-sm font-semibold text-white hover:text-white"
+            onClick={handleIsInitializedCheck}>
+            초기 설정 하러가기
+          </AlertDialogAction>
+          <AlertDialogCancel className="w-[50%] bg-gray-200 p-3 text-sm font-semibold text-white hover:bg-gray-300 hover:text-white">
+            취소
+          </AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/features/mainpage/ui/MainHeader.tsx
+++ b/src/features/mainpage/ui/MainHeader.tsx
@@ -1,15 +1,27 @@
+import { CopleCheckAlert } from "./CopleCheckAlert";
+import { InitializedCheckAlert } from "./InitializedCheckAlert";
+
 interface MainHeaderProps {
   mainTitle: string;
   buttonText?: string;
   onClick?: () => void;
   disabled?: boolean;
+  isConnected?: boolean;
+  isInitialized?: boolean;
 }
 
-export const MainHeader = ({ mainTitle, buttonText, onClick, disabled = false }: MainHeaderProps) => {
+export const MainHeader = ({
+  mainTitle,
+  buttonText,
+  onClick,
+  disabled = false,
+  isConnected,
+  isInitialized,
+}: MainHeaderProps) => {
   return (
     <div className="mt-5 flex items-center justify-between">
       <h2 className="text-xl font-bold text-gray-900">{mainTitle}</h2>
-      {buttonText && onClick && (
+      {isInitialized && isConnected && buttonText && onClick && (
         <button
           onClick={onClick}
           disabled={disabled}
@@ -18,6 +30,8 @@ export const MainHeader = ({ mainTitle, buttonText, onClick, disabled = false }:
           <span>{">"}</span>
         </button>
       )}
+      {!isConnected && <CopleCheckAlert />}
+      {!isInitialized && <InitializedCheckAlert />}
     </div>
   );
 };

--- a/src/features/schedule/hooks/useScheduleForm.ts
+++ b/src/features/schedule/hooks/useScheduleForm.ts
@@ -12,8 +12,8 @@ export const useScheduleForm = (initialState?: Partial<InitialSchedule>) => {
   });
 
   const isValid = useMemo(
-    () => form.title.trim() !== "" && form.startDate !== "" && form.endDate !== "",
-    [form.title, form.startDate, form.endDate]
+    () => form.title.trim() !== "" && form.startDate !== "" && form.endDate !== "" && form.fatigue !== "",
+    [form.title, form.startDate, form.endDate, form.fatigue]
   );
 
   const updateField = useCallback(<K extends keyof InitialSchedule>(key: K, value: InitialSchedule[K]) => {

--- a/src/features/schedule/ui/MainScheduleCardList.tsx
+++ b/src/features/schedule/ui/MainScheduleCardList.tsx
@@ -8,7 +8,7 @@ export const MainScheduleCardList = () => {
   const { data: scheduleListData } = useGetScheduleList(selectedDay);
 
   return (
-    <div className="flex flex-col gap-3 px-4">
+    <div className="flex flex-col gap-3">
       {scheduleListData?.result.anniversaries.map(dday => <DdayCard key={dday.id} {...dday} className="bg-gray-50" />)}
       {scheduleListData?.result.schedules.map(schedule => (
         <ScheduleCard key={schedule.id} {...schedule} className="bg-gray-50" />

--- a/src/features/schedule/ui/MainScheduleCardList.tsx
+++ b/src/features/schedule/ui/MainScheduleCardList.tsx
@@ -2,6 +2,7 @@ import { useSelectedDate } from "@/features/schedule/context/SelectedDateContext
 import { useGetScheduleList } from "@/entities/schedule/query";
 import { ScheduleCard } from "./ScheduleCard";
 import { DdayCard } from "@/features/d-day/ui";
+import { CalendrDdayCard } from "./CalendrDdayCard";
 
 export const MainScheduleCardList = () => {
   const { selectedDay } = useSelectedDate();
@@ -9,7 +10,9 @@ export const MainScheduleCardList = () => {
 
   return (
     <div className="flex flex-col gap-3">
-      {scheduleListData?.result.anniversaries.map(dday => <DdayCard key={dday.id} {...dday} className="bg-gray-50" />)}
+      {scheduleListData?.result.anniversaries.map(dday => (
+        <CalendrDdayCard key={dday.id} {...dday} className="bg-gray-50" />
+      ))}
       {scheduleListData?.result.schedules.map(schedule => (
         <ScheduleCard key={schedule.id} {...schedule} className="bg-gray-50" />
       ))}

--- a/src/features/schedule/ui/MainScheduleCardList.tsx
+++ b/src/features/schedule/ui/MainScheduleCardList.tsx
@@ -1,7 +1,6 @@
 import { useSelectedDate } from "@/features/schedule/context/SelectedDateContext";
 import { useGetScheduleList } from "@/entities/schedule/query";
 import { ScheduleCard } from "./ScheduleCard";
-import { DdayCard } from "@/features/d-day/ui";
 import { CalendrDdayCard } from "./CalendrDdayCard";
 
 export const MainScheduleCardList = () => {

--- a/src/features/schedule/ui/MiniCalendar.tsx
+++ b/src/features/schedule/ui/MiniCalendar.tsx
@@ -4,9 +4,14 @@ import { useGetWeekSchedule } from "@/entities/schedule/query";
 import { useSelectedDate } from "../context/SelectedDateContext";
 import { FATIGUE_TAG } from "../model";
 
+interface MiniCalendarProps {
+  isConnected: boolean;
+  isInitialized: boolean;
+}
+
 const normalizeDate = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
-export const MiniCalendar = () => {
+export const MiniCalendar = ({ isConnected, isInitialized }: MiniCalendarProps) => {
   const { selectedDay, setSelectedDay } = useSelectedDate();
   const { data: weekScheduleData } = useGetWeekSchedule();
 
@@ -72,7 +77,7 @@ export const MiniCalendar = () => {
   return (
     <>
       {/* 요일 헤더 */}
-      <div className="grid grid-cols-7 px-1.5 text-center font-medium">
+      <div className="grid grid-cols-7 text-center font-medium">
         {shiftedDays.map((day, idx) => (
           <div key={idx} className={day === "일" ? "text-red-0" : ""}>
             {day}
@@ -81,7 +86,7 @@ export const MiniCalendar = () => {
       </div>
 
       {/* 날짜 셀 */}
-      <div className="mb-7 grid grid-cols-7 gap-x-1 px-1.5 py-3 text-center">
+      <div className="mb-7 grid grid-cols-7 gap-x-1 py-3 text-center">
         {dateList.map((date, idx) => {
           const isToday = isSameDate(date, today);
           const isSelected = selectedDay && isSameDate(date, selectedDay);
@@ -119,7 +124,7 @@ export const MiniCalendar = () => {
                 {date ? date.getDate() : ""}
               </p>
               {/* 연속 일정 그리드 */}
-              {currentDayMaxRow > 0 && (
+              {currentDayMaxRow > 0 && isConnected && isInitialized && (
                 <div
                   className="mb-1 grid w-full gap-1.5"
                   style={{ gridTemplateRows: `repeat(${currentDayMaxRow}, 14px)` }}>
@@ -159,16 +164,18 @@ export const MiniCalendar = () => {
                 </div>
               )}
               {/* 단일 일정 스택 */}
-              <div className="flex w-full flex-col gap-1">
-                {singleDayTags.map(tag => {
-                  const { bgColor, textColor } = FATIGUE_TAG[tag.fatigue || "VERY_TIRED"];
-                  return (
-                    <div key={tag.id} className={`flex h-4 w-full items-center rounded-[4px] ${bgColor}`}>
-                      <p className={`w-full truncate text-[10px] ${textColor}`}>{tag.title}</p>
-                    </div>
-                  );
-                })}
-              </div>
+              {isConnected && isInitialized && (
+                <div className="flex w-full flex-col gap-1">
+                  {singleDayTags.map(tag => {
+                    const { bgColor, textColor } = FATIGUE_TAG[tag.fatigue || "VERY_TIRED"];
+                    return (
+                      <div key={tag.id} className={`flex h-4 w-full items-center rounded-[4px] ${bgColor}`}>
+                        <p className={`w-full truncate text-[10px] ${textColor}`}>{tag.title}</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/features/schedule/ui/MiniCalendar.tsx
+++ b/src/features/schedule/ui/MiniCalendar.tsx
@@ -28,6 +28,17 @@ export const MiniCalendar = ({ isConnected, isInitialized }: MiniCalendarProps) 
       }))
     );
   }, [weekScheduleData]);
+
+  const normalizedAnniversaries = useMemo(() => {
+    return (
+      weekScheduleData &&
+      weekScheduleData.result.anniversaries.map(anniversary => ({
+        ...anniversary,
+        date: normalizeDate(new Date(anniversary.anniversaryDate)),
+      }))
+    );
+  }, [weekScheduleData]);
+
   const shiftedDays = getShiftedWeekdays(today);
   const dateList = getDateList(today, 7, 1);
 
@@ -100,6 +111,14 @@ export const MiniCalendar = ({ isConnected, isInitialized }: MiniCalendarProps) 
                 })
               : [];
 
+          const dayAnniversaries =
+            date != null && normalizedAnniversaries
+              ? normalizedAnniversaries.filter(anniversary => {
+                  const d = normalizeDate(date);
+                  return d.getTime() === anniversary.date.getTime();
+                })
+              : [];
+
           // 연속 일정과 단일 일정 분리
           const continuousTags = dayTags.filter(tag => tag.startDate.getTime() !== tag.endDate.getTime());
           const singleDayTags = dayTags.filter(tag => tag.startDate.getTime() === tag.endDate.getTime());
@@ -166,6 +185,14 @@ export const MiniCalendar = ({ isConnected, isInitialized }: MiniCalendarProps) 
               {/* 단일 일정 스택 */}
               {isConnected && isInitialized && (
                 <div className="flex w-full flex-col gap-1">
+                  {/* 기념일 표시 */}
+                  {dayAnniversaries.map((anniversary, index) => (
+                    <div
+                      key={`${anniversary.title}-${index}`}
+                      className="flex h-4 w-full items-center rounded-[4px] bg-[rgb(255,232,117,0.6)]">
+                      <p className="w-full truncate px-1 text-[10px] text-[#7B6901]">{anniversary.title}</p>
+                    </div>
+                  ))}
                   {singleDayTags.map(tag => {
                     const { bgColor, textColor } = FATIGUE_TAG[tag.fatigue || "VERY_TIRED"];
                     return (

--- a/src/pages/calendar/NewSchedule.tsx
+++ b/src/pages/calendar/NewSchedule.tsx
@@ -71,10 +71,10 @@ export const CalendarNewSchedule = () => {
 
   return (
     <>
-      <header className="mt-[70px] mb-8 flex flex-col items-center gap-7">
+      <header className="mt-[20px] mb-8 flex flex-col items-center gap-7">
         <div className="">
           <h1 className="text-xl font-semibold text-gray-900">생성하기</h1>
-          <Button variant="ghost" size="sIcon" className="absolute top-17 left-5" onClick={goBack}>
+          <Button variant="ghost" size="sIcon" className="absolute top-5 left-5" onClick={goBack}>
             <img src={backIcon} alt="뒤로가기" />
           </Button>
         </div>

--- a/src/pages/calendar/ScheduleDetail.tsx
+++ b/src/pages/calendar/ScheduleDetail.tsx
@@ -43,7 +43,7 @@ export const CalendarScheduleDetail = () => {
   return (
     <>
       <div className="px-[22px]">
-        <header className="mt-[70px] mb-4 flex items-center justify-between">
+        <header className="mt-[20px] mb-4 flex items-center justify-between">
           <Button variant="ghost" size="sIcon" onClick={goBack}>
             <img src={backIcon} alt="뒤로가기" />
           </Button>

--- a/src/pages/dday/DdayListPage.tsx
+++ b/src/pages/dday/DdayListPage.tsx
@@ -53,10 +53,10 @@ export const CalendarDdayList = () => {
     <div className="px-[22px]">
       {/* 헤더 영역 */}
       <header className="relative flex items-center justify-center">
-        <Button variant="ghost" size="sIcon" className="absolute top-[60px] left-0" onClick={goBack}>
+        <Button variant="ghost" size="sIcon" className="absolute top-5 left-0" onClick={goBack}>
           <img src={backIcon} alt="뒤로가기" />
         </Button>
-        <h1 className="pt-[60px] text-xl font-semibold text-gray-900">디데이</h1>
+        <h1 className="pt-[20px] text-xl font-semibold text-gray-900">디데이</h1>
       </header>
 
       {/* 메인 콘텐츠 영역 */}

--- a/src/pages/dday/NewDday.tsx
+++ b/src/pages/dday/NewDday.tsx
@@ -27,7 +27,7 @@ export const NewDday = () => {
 
   // 상태
   const isEditMode = !!ddayId;
-  console.log(isEditMode);
+
   // 상태 및 폼 관련 커스텀 훅
   const { newDdayState, handleChange, isFormValid } = useNewDdayForm();
 

--- a/src/pages/dday/NewDday.tsx
+++ b/src/pages/dday/NewDday.tsx
@@ -74,10 +74,10 @@ export const NewDday = () => {
 
   return (
     <>
-      <header className="mt-[70px] mb-8 flex flex-col items-center gap-7">
+      <header className="mt-5 mb-8 flex flex-col items-center gap-7">
         <div className="">
           <h1 className="text-xl font-semibold text-gray-900">생성하기</h1>
-          <Button variant="ghost" size="sIcon" className="absolute top-17 left-5" onClick={handleDone}>
+          <Button variant="ghost" size="sIcon" className="absolute top-5 left-5" onClick={handleDone}>
             <img src={backIcon} alt="뒤로가기" />
           </Button>
         </div>

--- a/src/pages/dday/NewDday.tsx
+++ b/src/pages/dday/NewDday.tsx
@@ -27,15 +27,16 @@ export const NewDday = () => {
 
   // 상태
   const isEditMode = !!ddayId;
+  console.log(isEditMode);
   // 상태 및 폼 관련 커스텀 훅
   const { newDdayState, handleChange, isFormValid } = useNewDdayForm();
 
+  useInitializeDdayFormFromCache(ddayId!, handleChange, from);
+
   // API 훅
   const { mutate: ddayMutate } = useCreateDdayMutation(newDdayState);
-  const { mutate: ddayUpdateMutate } = useUpdateDdayMutation(newDdayState);
   const { mutate: ddayDeleteMutate } = useDeleteDdayMutation(ddayId!, newDdayState.date);
-
-  useInitializeDdayFormFromCache(ddayId!, handleChange, from);
+  const { mutate: ddayUpdateMutate } = useUpdateDdayMutation(newDdayState);
 
   // 이벤트 핸들러
   const handlePostDday = async () => {
@@ -64,6 +65,9 @@ export const NewDday = () => {
       onSuccess: () => {
         alert("디데이가 삭제되었습니다.");
         handleDone();
+      },
+      onError: error => {
+        console.log(error);
       },
     });
   };

--- a/src/pages/letter/LetterDetail.tsx
+++ b/src/pages/letter/LetterDetail.tsx
@@ -68,10 +68,10 @@ export const LetterDetailPage = () => {
     <>
       {/* 헤더 영역 */}
       <header className="relative mb-8 flex items-center justify-center">
-        <Button variant="ghost" size="sIcon" className="absolute top-[70px] left-5" onClick={goBack}>
+        <Button variant="ghost" size="sIcon" className="absolute top-5 left-5" onClick={goBack}>
           <img src={backIcon} alt="뒤로가기" />
         </Button>
-        <h1 className="pt-[70px] text-xl font-semibold text-gray-900">
+        <h1 className="pt-5 text-xl font-semibold text-gray-900">
           {formatDateKoreanWithWeekday(letterDetailData.result.letter.createdAt)}
         </h1>
       </header>

--- a/src/pages/letter/LetterDetail.tsx
+++ b/src/pages/letter/LetterDetail.tsx
@@ -145,7 +145,7 @@ export const LetterDetailPage = () => {
 
         {/* 댓글 입력 폼 */}
         <form
-          className="fixed bottom-0 left-1/2 mx-auto mb-8 max-h-25 w-[375px] -translate-x-1/2 bg-white px-5 shadow-[0px_3px_12px_4px_rgba(218,218,218,0.15)]"
+          className="fixed -bottom-8 left-1/2 mx-auto mb-8 max-h-25 w-[375px] -translate-x-1/2 bg-white px-5 shadow-[0px_3px_12px_4px_rgba(218,218,218,0.15)]"
           onSubmit={handleCommentSubmit}>
           <div className="relative flex items-center">
             <Textarea
@@ -153,7 +153,7 @@ export const LetterDetailPage = () => {
               placeholder="댓글을 작성해 주세요."
               name="content"
               id="content"
-              maxLength={150}
+              maxLength={80}
             />
             <Button type="submit" variant="active" className="absolute right-2 z-10">
               입력

--- a/src/pages/letter/LetterListPage.tsx
+++ b/src/pages/letter/LetterListPage.tsx
@@ -49,10 +49,10 @@ export const LetterListPage = () => {
     <div className="px-[22px]">
       {/* 헤더 영역 */}
       <header className="relative flex items-center justify-center">
-        <Button variant="ghost" size="sIcon" className="absolute top-[70px] left-0" onClick={handleBack}>
+        <Button variant="ghost" size="sIcon" className="absolute top-5 left-0" onClick={handleBack}>
           <img src={backIcon} alt="뒤로가기" />
         </Button>
-        <h1 className="pt-[70px] text-xl font-semibold text-gray-900">편지</h1>
+        <h1 className="pt-5 text-xl font-semibold text-gray-900">편지</h1>
       </header>
 
       {/* 메인 콘텐츠 영역 */}

--- a/src/pages/letter/LetterListPage.tsx
+++ b/src/pages/letter/LetterListPage.tsx
@@ -65,7 +65,9 @@ export const LetterListPage = () => {
             <img src={blackHeart} alt="캘린더 아이콘" />
             <h2 className="text-xl font-semibold text-gray-900">{coupleNickname?.result.coupleNickname}</h2>
             <h2 className="text-xl font-semibold text-gray-900">님의 편지</h2>
-            <p className="text-md font-semibold text-gray-500">2</p>
+            <p className="text-md font-semibold text-gray-500">
+              {letterListData.pages.reduce((total, page) => total + page.data.length, 0)}
+            </p>
           </section>
         )}
 

--- a/src/pages/letter/LetterListPage.tsx
+++ b/src/pages/letter/LetterListPage.tsx
@@ -15,8 +15,13 @@ import { useCoupleNickname } from "@/entities/couple_nickname";
 
 // 훅
 import { useIntersect } from "@/shared/hooks";
+import { useLocation, useNavigate } from "react-router";
 
 export const LetterListPage = () => {
+  // 라우터 훅
+  const location = useLocation();
+  const navigate = useNavigate();
+
   // API 훅
   const { data: letterListData, fetchNextPage, isFetched } = useGetLetterList();
   const { getNickName } = useCoupleNickname();
@@ -31,11 +36,20 @@ export const LetterListPage = () => {
     return;
   }
 
+  const handleBack = () => {
+    const previousPath = location.state?.previousPath;
+    if (previousPath) {
+      navigate(previousPath);
+    } else {
+      navigate(-1);
+    }
+  };
+
   return (
     <div className="px-[22px]">
       {/* 헤더 영역 */}
       <header className="relative flex items-center justify-center">
-        <Button variant="ghost" size="sIcon" className="absolute top-[70px] left-0">
+        <Button variant="ghost" size="sIcon" className="absolute top-[70px] left-0" onClick={handleBack}>
           <img src={backIcon} alt="뒤로가기" />
         </Button>
         <h1 className="pt-[70px] text-xl font-semibold text-gray-900">편지</h1>

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -18,11 +18,11 @@ const NotConnectedPage = () => {
       </div>
       <div className="relative z-10 -mt-13 flex-grow rounded-t-[20px] bg-gray-50">
         <main className="container mx-auto max-w-[1920px] px-4 pt-15 pb-[95px]">
-          <div className="grid w-full gap-4 ">
+          <div className="grid w-full gap-4">
             <StatusSection isConnected={false} isInitialized={false} />
-            <ScheduleSection />
+            <ScheduleSection isConnected={false} isInitialized={false} />
             <LetterSection isConnected={false} isInitialized={false} />
-            <DDaySection isConnected={false} />
+            <DDaySection isConnected={false} isInitialized={false} />
           </div>
         </main>
       </div>
@@ -44,9 +44,9 @@ const NotInitializedPage = ({ isLoading }: { isLoading: boolean }) => {
         <main className="container mx-auto max-w-full px-4 pt-15 pb-[95px]">
           <div className="grid w-full gap-4">
             <StatusSection isConnected={true} isInitialized={false} />
-            <ScheduleSection />
+            <ScheduleSection isConnected={true} isInitialized={false} />
             <LetterSection isConnected={true} isInitialized={false} />
-            <DDaySection isConnected={false} />
+            <DDaySection isConnected={true} isInitialized={false} />
           </div>
         </main>
       </div>
@@ -61,16 +61,16 @@ const InitializedPage = ({ isLoading }: { isLoading: boolean }) => {
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
       <TopSection isConnected={true} isInitialized={true} isLoading={isLoading} />
-      <div >
+      <div>
         <SpecialDateSection isConnected={true} isInitialized={true} isLoading={isLoading} />
       </div>
       <div className="relative z-10 -mt-13 flex-grow rounded-t-[20px] bg-gray-50">
         <main className="container mx-auto max-w-[1920px] px-4 pt-15 pb-[95px]">
           <div className="grid w-full gap-4">
             <StatusSection isConnected={true} isInitialized={true} />
-            <ScheduleSection />
+            <ScheduleSection isConnected={true} isInitialized={true} />
             <LetterSection isConnected={true} isInitialized={true} />
-            <DDaySection isConnected={true} />
+            <DDaySection isConnected={true} isInitialized={true} />
           </div>
         </main>
       </div>

--- a/src/shared/firebase/setupFCM.ts
+++ b/src/shared/firebase/setupFCM.ts
@@ -39,9 +39,6 @@ export async function requestNotificationPermission(): Promise<string | null> {
         vapidKey: VAPID_KEY,
         serviceWorkerRegistration: swRegistration,
       });
-
-      console.log("FCM 토큰:", token);
-
       // 포그라운드 알림 수신
       onMessage(messaging, payload => {
         console.log("포그라운드 알림 수신:", payload);


### PR DESCRIPTION
## 이슈 넘버

- #52 

## 구현 사항

- [x] 메인 - 도착한 편지 더보기 클릭 시 캘린더 리스트로 이동
- [ ] 메인 - 우리의 일정 클릭 시 로딩 설정
- [x] 디데이가 없을 때 띄워줄 UI가 부재합니다.
- [ ] 메인 하단에서 캘린더 진입 시 캘린더 하단으로 로드되는 문제
- [ ] 연결 일정 설정 시 마진에 붙으면 텍스트가 깨지는 문제.
- [ ] 연결 일정 상세 설정 클릭 시 (디데이) 막아두기
- [x] 디데이 등록 페이지 오류
- [x] 디데이 목록 상단 마진 줄이기
- [ ] 디데이 수정이 안되고 생성.
- [ ] 메인 - 우리의 일정 (연결일정) UI 수정
- [x] 메인 - 도착한 편지 클릭시 해당 일정 상세로 이동,
- [x] 편지 작성 시 바텀시트 조금 더 여유있게 올라가야 함
- [x] 편지 작성 시 사진 등록 제한 설정(3개),
- [x] 편지 작성 시 X 버튼 사진에 붙어서 안나오는 문제,
- [x] 편지 작성 제목 20자로 제한,
- [x] 편지 작성자만 편집/삭제 가능하도록 UI 수정
- [x] 편지 등록 클릭 시 한번만 편지 등록 가능하도록 수정
- [x] 댓글작성 바가 하단에 고정되어 있지 않는 문제
- [x] 편지 리스트 뒤로가기 버튼 작동이 안되는 문제
- [x] 편지 리스트 갯수가 연동이 안되는 문제

